### PR TITLE
Add type hints

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,9 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-      - run: pip install flake8 black isort
+      - run: pip install -e .
+      - run: pip install flake8 black isort mypy
       - run: python -m flake8 .
+      - run: python -m mypy .
       - run: python -m black --check .
       - run: python -m isort --check .

--- a/l10n_parser/__init__.py
+++ b/l10n_parser/__init__.py
@@ -58,7 +58,16 @@ __all__ = [
     "PropertiesEntity",
 ]
 
-__constructors = []
+
+__constructors = [
+    ("strings.*\\.xml$", AndroidParser()),
+    ("\\.dtd$", DTDParser()),
+    ("\\.properties$", PropertiesParser()),
+    ("\\.ini$", IniParser()),
+    ("\\.inc$", DefinesParser()),
+    ("\\.ftl$", FluentParser()),
+    ("\\.pot?$", PoParser()),
+]
 
 
 def getParser(path: str) -> Parser:
@@ -73,14 +82,3 @@ def hasParser(path):
         return bool(getParser(path))
     except UserWarning:
         return False
-
-
-__constructors = [
-    ("strings.*\\.xml$", AndroidParser()),
-    ("\\.dtd$", DTDParser()),
-    ("\\.properties$", PropertiesParser()),
-    ("\\.ini$", IniParser()),
-    ("\\.inc$", DefinesParser()),
-    ("\\.ftl$", FluentParser()),
-    ("\\.pot?$", PoParser()),
-]

--- a/l10n_parser/__init__.py
+++ b/l10n_parser/__init__.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from __future__ import annotations
+
 import re
 
 from .android import AndroidParser
@@ -59,7 +61,7 @@ __all__ = [
 __constructors = []
 
 
-def getParser(path):
+def getParser(path: str) -> Parser:
     for item in __constructors:
         if re.search(item[0], path):
             return item[1]

--- a/l10n_parser/__init__.py
+++ b/l10n_parser/__init__.py
@@ -77,7 +77,7 @@ def getParser(path: str) -> Parser:
     raise UserWarning("Cannot find Parser")
 
 
-def hasParser(path):
+def hasParser(path: str) -> bool:
     try:
         return bool(getParser(path))
     except UserWarning:

--- a/l10n_parser/android.py
+++ b/l10n_parser/android.py
@@ -11,7 +11,9 @@ break the full parsing, and result in a single Junk entry.
 """
 
 from __future__ import annotations
+
 import re
+from typing import TYPE_CHECKING, Iterator, Optional, Tuple, Union
 from xml.dom import minidom
 from xml.dom.minidom import Node
 
@@ -25,7 +27,6 @@ from .base import (
     StickyEntry,
     Whitespace,
 )
-from typing import TYPE_CHECKING, Iterator, Optional, Tuple, Union
 
 if TYPE_CHECKING:
     from xml.dom.minicompat import NodeList
@@ -35,8 +36,8 @@ class AndroidEntity(Entity):
     def __init__(
         self,
         ctx: Parser.Context,
-        pre_comment: "XMLComment",
-        white_space: "XMLWhitespace",
+        pre_comment: Union[XMLComment, None],
+        white_space: Union[XMLWhitespace, None],
         node: minidom.Element,
         all: str,
         key: str,
@@ -46,7 +47,7 @@ class AndroidEntity(Entity):
         # fill out superclass as good as we can right now
         # most span can get modified at endElement
         super().__init__(
-            ctx, pre_comment, white_space, (None, None), (None, None), (None, None)
+            ctx, pre_comment, white_space, (None, None), (None, None), (None, None)  # type: ignore
         )
         self.node = node
         self._all_literal = all
@@ -86,7 +87,7 @@ class AndroidEntity(Entity):
             for child in clone.childNodes:
                 if child.nodeType == Node.CDATA_SECTION_NODE:
                     break
-        child.data = raw_val
+        child.data = raw_val  # type: ignore
         all = []
         if self.pre_comment is not None:
             all.append(self.pre_comment.all)
@@ -120,7 +121,7 @@ class NodeMixin:
         return (0, offset)
 
 
-class XMLWhitespace(NodeMixin, Whitespace):
+class XMLWhitespace(NodeMixin, Whitespace):  # type:ignore[misc]
     pass
 
 
@@ -149,7 +150,7 @@ class DocumentWrapper(NodeMixin, StickyEntry):
 
 class XMLJunk(Junk):
     def __init__(self, all: str) -> None:
-        super().__init__(None, (0, 0))
+        super().__init__(None, (0, 0))  # type: ignore
         self._all_literal = all
 
     @property
@@ -193,7 +194,7 @@ class AndroidParser(Parser):
         super().__init__()
         self.last_comment = None
 
-    def walk(
+    def walk(  # type:ignore[override]
         self, only_localizable: bool = False
     ) -> Iterator[
         Union[DocumentWrapper, XMLWhitespace, AndroidEntity, XMLComment, XMLJunk]
@@ -279,7 +280,7 @@ class AndroidParser(Parser):
     ) -> Union[AndroidEntity, XMLJunk]:
         if element.nodeName == "string" and element.hasAttribute("name"):
             return AndroidEntity(
-                self.ctx,
+                self.ctx,  # type: ignore
                 current_comment,
                 white_space,
                 element,

--- a/l10n_parser/android.py
+++ b/l10n_parser/android.py
@@ -173,7 +173,7 @@ def textContent(node: minidom.Element) -> str:
         or node.childNodes[0].nodeType != minidom.Node.TEXT_NODE
     ):
         # Return something, we'll fail in checks on this
-        return cast(str, node.toxml())
+        return node.toxml()
     return cast(str, node.childNodes[0].data)
 
 

--- a/l10n_parser/android.py
+++ b/l10n_parser/android.py
@@ -10,7 +10,7 @@ As we're using a built-in XML parser underneath, errors on that level
 break the full parsing, and result in a single Junk entry.
 """
 
-
+from __future__ import annotations
 import re
 from xml.dom import minidom
 from xml.dom.minidom import Node
@@ -25,10 +25,24 @@ from .base import (
     StickyEntry,
     Whitespace,
 )
+from typing import TYPE_CHECKING, Iterator, Optional, Tuple, Union
+
+if TYPE_CHECKING:
+    from xml.dom.minicompat import NodeList
 
 
 class AndroidEntity(Entity):
-    def __init__(self, ctx, pre_comment, white_space, node, all, key, raw_val, val):
+    def __init__(
+        self,
+        ctx: Parser.Context,
+        pre_comment: "XMLComment",
+        white_space: "XMLWhitespace",
+        node: minidom.Element,
+        all: str,
+        key: str,
+        raw_val: str,
+        val: str,
+    ) -> None:
         # fill out superclass as good as we can right now
         # most span can get modified at endElement
         super().__init__(
@@ -41,7 +55,7 @@ class AndroidEntity(Entity):
         self._val_literal = val
 
     @property
-    def all(self):
+    def all(self) -> str:
         chunks = []
         if self.pre_comment is not None:
             chunks.append(self.pre_comment.all)
@@ -51,11 +65,11 @@ class AndroidEntity(Entity):
         return "".join(chunks)
 
     @property
-    def key(self):
+    def key(self) -> str:
         return self._key_literal
 
     @property
-    def raw_val(self):
+    def raw_val(self) -> str:
         return self._raw_val_literal
 
     def position(self, offset=0):
@@ -64,7 +78,7 @@ class AndroidEntity(Entity):
     def value_position(self, offset=0):
         return (0, offset)
 
-    def wrap(self, raw_val):
+    def wrap(self, raw_val: str) -> LiteralEntity:
         clone = self.node.cloneNode(True)
         if clone.childNodes.length == 1:
             child = clone.childNodes[0]
@@ -83,12 +97,12 @@ class AndroidEntity(Entity):
 
 
 class NodeMixin:
-    def __init__(self, all, value):
+    def __init__(self, all: str, value: str) -> None:
         self._all_literal = all
         self._val_literal = value
 
     @property
-    def all(self):
+    def all(self) -> str:
         return self._all_literal
 
     @property
@@ -96,7 +110,7 @@ class NodeMixin:
         return self._all_literal
 
     @property
-    def raw_val(self):
+    def raw_val(self) -> str:
         return self._val_literal
 
     def position(self, offset=0):
@@ -112,7 +126,7 @@ class XMLWhitespace(NodeMixin, Whitespace):
 
 class XMLComment(NodeMixin, Comment):
     @property
-    def val(self):
+    def val(self) -> str:
         return self._val_literal
 
     @property
@@ -123,23 +137,23 @@ class XMLComment(NodeMixin, Comment):
 # DocumentWrapper is sticky in serialization.
 # Always keep the one from the reference document.
 class DocumentWrapper(NodeMixin, StickyEntry):
-    def __init__(self, key, all):
+    def __init__(self, key: str, all: str) -> None:
         self._all_literal = all
         self._val_literal = all
         self._key_literal = key
 
     @property
-    def key(self):
+    def key(self) -> str:
         return self._key_literal
 
 
 class XMLJunk(Junk):
-    def __init__(self, all):
+    def __init__(self, all: str) -> None:
         super().__init__(None, (0, 0))
         self._all_literal = all
 
     @property
-    def all(self):
+    def all(self) -> str:
         return self._all_literal
 
     def position(self, offset=0):
@@ -149,7 +163,7 @@ class XMLJunk(Junk):
         return (0, offset)
 
 
-def textContent(node):
+def textContent(node: minidom.Element) -> str:
     if node.childNodes.length == 0:
         return ""
     for child in node.childNodes:
@@ -167,7 +181,7 @@ def textContent(node):
 NEWLINE = re.compile(r"[ \t]*\n[ \t]*")
 
 
-def normalize(val):
+def normalize(val: str) -> str:
     return NEWLINE.sub("\n", val.strip(" \t"))
 
 
@@ -175,11 +189,15 @@ class AndroidParser(Parser):
     # Android does l10n fallback at runtime, don't merge en-US strings
     capabilities = CAN_SKIP
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.last_comment = None
 
-    def walk(self, only_localizable=False):
+    def walk(
+        self, only_localizable: bool = False
+    ) -> Iterator[
+        Union[DocumentWrapper, XMLWhitespace, AndroidEntity, XMLComment, XMLJunk]
+    ]:
         if not self.ctx:
             # loading file failed, or we just didn't load anything
             return
@@ -253,7 +271,12 @@ class AndroidParser(Parser):
         if not only_localizable:
             yield DocumentWrapper("</resources>", "</resources>\n")
 
-    def handleElement(self, element, current_comment, white_space):
+    def handleElement(
+        self,
+        element: minidom.Element,
+        current_comment: Optional[XMLComment],
+        white_space: Optional[XMLWhitespace],
+    ) -> Union[AndroidEntity, XMLJunk]:
         if element.nodeName == "string" and element.hasAttribute("name"):
             return AndroidEntity(
                 self.ctx,
@@ -268,7 +291,9 @@ class AndroidParser(Parser):
         else:
             return XMLJunk(element.toxml())
 
-    def handleComment(self, node, root_children, child_num):
+    def handleComment(
+        self, node: minidom.Comment, root_children: NodeList, child_num: int
+    ) -> Tuple[XMLComment, int]:
         all = node.toxml()
         val = normalize(node.nodeValue)
         while True:

--- a/l10n_parser/base.py
+++ b/l10n_parser/base.py
@@ -8,13 +8,17 @@ import bisect
 import codecs
 import re
 from collections import Counter
-from typing import TYPE_CHECKING, Any, Iterator, Optional, Tuple, Union
-
-if TYPE_CHECKING:
-    from .android import XMLComment, XMLWhitespace
-    from .defines import DefinesParser
-    from .dtd import DTDEntity, DTDParser
-
+from typing import (
+    Any,
+    Iterable,
+    Iterator,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+    overload,
+)
 
 # The allowed capabilities for the Parsers.  They define the exact strategy
 # used by ContentComparer.merge.
@@ -47,14 +51,12 @@ class Entry:
 
     def __init__(
         self,
-        ctx: Optional[Union[Parser.Context, DefinesParser.Context]],
-        pre_comment: Optional[
-            Union[XMLComment, DTDParser.Comment, DefinesParser.Comment]
-        ],
-        inner_white: Optional[Union[XMLWhitespace, Whitespace]],
-        span: Optional[Union[Tuple[None, None], Tuple[int, int]]],
-        key_span: Optional[Union[Tuple[None, None], Tuple[int, int]]],
-        val_span: Optional[Union[Tuple[None, None], Tuple[int, int]]],
+        ctx: Parser.Context,
+        pre_comment: Optional[Comment],
+        inner_white: Optional[Whitespace],
+        span: Tuple[int, int],
+        key_span: Tuple[int, int],
+        val_span: Tuple[int, int],
     ) -> None:
         self.ctx = ctx
         self.span = span
@@ -105,13 +107,13 @@ class Entry:
         return self.ctx.contents[self.key_span[0] : self.key_span[1]]
 
     @property
-    def raw_val(self) -> str:
+    def raw_val(self) -> Union[str, None]:
         if self.val_span is None:
             return None
         return self.ctx.contents[self.val_span[0] : self.val_span[1]]
 
     @property
-    def val(self) -> str:
+    def val(self) -> Union[str, None]:
         return self.raw_val
 
     def __repr__(self) -> str:
@@ -124,11 +126,14 @@ class Entry:
         """Count the words in an English string.
         Replace a couple of xml markup to make that safer, too.
         """
-        value = self.re_br.sub("\n", self.val)
+        value = self.val
+        if value is None:
+            return 0
+        value = self.re_br.sub("\n", value)
         value = self.re_sgml.sub("", value)
         return len(value.split())
 
-    def equals(self, other: Union[Entity, DTDEntity, LiteralEntity]) -> bool:
+    def equals(self, other: Entity) -> bool:
         return self.key == other.key and self.val == other.val
 
 
@@ -150,11 +155,11 @@ class Entity(Entry):
         """
         return True
 
-    def unwrap(self):
+    def unwrap(self) -> Optional[str]:
         """Return the literal value to be used by tools."""
         return self.raw_val
 
-    def wrap(self, raw_val):
+    def wrap(self, raw_val: str) -> LiteralEntity:
         """Create literal entity based on reference and raw value.
 
         This is used by the serialization logic.
@@ -175,7 +180,7 @@ class LiteralEntity(Entity):
     """
 
     def __init__(self, key: str, val: str, all: str) -> None:
-        super().__init__(None, None, None, None, None, None)
+        super().__init__(None, None, None, None, None, None)  # type: ignore
         self._key = key
         self._raw_val = val
         self._all = all
@@ -185,7 +190,7 @@ class LiteralEntity(Entity):
         return self._key
 
     @property
-    def raw_val(self):
+    def raw_val(self) -> str:
         return self._raw_val
 
     @property
@@ -201,16 +206,14 @@ class PlaceholderEntity(LiteralEntity):
 
 
 class Comment(Entry):
-    def __init__(
-        self, ctx: Union[Parser.Context, DefinesParser.Context], span: Tuple[int, int]
-    ) -> None:
+    def __init__(self, ctx: Parser.Context, span: Tuple[int, int]) -> None:
         self.ctx = ctx
         self.span = span
-        self.val_span = None
-        self._val_cache = None
+        self.val_span = None  # type:ignore
+        self._val_cache: Optional[str] = None
 
     @property
-    def key(self):
+    def key(self) -> None:  # type:ignore[override]
         return None
 
     @property
@@ -251,7 +254,7 @@ class Junk:
 
     def __init__(
         self,
-        ctx: Optional[Union[Parser.Context, DefinesParser.Context]],
+        ctx: Parser.Context,
         span: Tuple[int, int],
     ) -> None:
         self.ctx = ctx
@@ -299,9 +302,10 @@ class Whitespace(Entry):
     if allowed
     """
 
-    def __init__(
-        self, ctx: Union[Parser.Context, DefinesParser.Context], span: Tuple[int, int]
-    ) -> None:
+    raw_val: str
+    val: str
+
+    def __init__(self, ctx: Parser.Context, span: Tuple[int, int]) -> None:
         self.ctx = ctx
         self.span = self.key_span = self.val_span = span
 
@@ -315,20 +319,24 @@ class BadEntity(ValueError):
     pass
 
 
+Comment_ = Comment
+
+
 class Parser:
     capabilities = CAN_SKIP | CAN_MERGE
     reWhitespace = re.compile("[ \t\r\n]+", re.M)
     Comment = Comment
     # NotImplementedError would be great, but also tedious
-    reKey = reComment = None
+    reKey: re.Pattern[str] = None  # type: ignore
+    reComment: re.Pattern[str] = None  # type: ignore
 
     class Context:
         "Fixture for content and line numbers"
 
-        def __init__(self, contents):
+        def __init__(self, contents: str):
             self.contents = contents
             # cache split lines
-            self._lines = None
+            self._lines: Optional[List[int]] = None
 
         def linecol(self, position: int) -> Tuple[int, int]:
             "Returns 1-based line and column numbers."
@@ -345,7 +353,7 @@ class Parser:
     def __init__(self) -> None:
         if not hasattr(self, "encoding"):
             self.encoding = "utf-8"
-        self.ctx = None
+        self.ctx: Optional[Parser.Context] = None
 
     def readFile(self, file: str) -> None:
         """Read contents from disk, with universal_newlines"""
@@ -357,14 +365,22 @@ class Parser:
 
         contents are in native encoding, but with normalized line endings.
         """
-        (contents, _) = codecs.getdecoder(self.encoding)(contents, "replace")
-        self.readUnicode(contents)
+        (string, _) = codecs.getdecoder(self.encoding)(contents, "replace")
+        self.readUnicode(string)
 
     def readUnicode(self, contents: str) -> None:
         self.ctx = self.Context(contents)
 
-    def __iter__(self) -> Iterator[Any]:
+    def __iter__(self) -> Iterator[Union[Entity, Junk]]:
         return self.walk(only_localizable=True)
+
+    @overload
+    def walk(self, only_localizable: Literal[True]) -> Iterator[Union[Entity, Junk]]:
+        ...
+
+    @overload
+    def walk(self, only_localizable: bool = False) -> Iterator[Any]:
+        ...
 
     def walk(self, only_localizable: bool = False) -> Iterator[Any]:
         if not self.ctx:
@@ -377,16 +393,12 @@ class Parser:
         while next_offset < len(contents):
             entity = self.getNext(ctx, next_offset)
 
-            if isinstance(entity, (Entity, Junk)):
-                yield entity
-            elif not only_localizable:
+            if isinstance(entity, (Entity, Junk)) or not only_localizable:
                 yield entity
 
             next_offset = entity.span[1]
 
-    def getNext(
-        self, ctx: Parser.Context, offset: int
-    ) -> Union[Junk, DTDEntity, DTDParser.Comment, Whitespace]:
+    def getNext(self, ctx: Parser.Context, offset: int) -> Union[Entry, Junk]:
         """Parse the next fragment.
 
         Parse comments first, then white-space.
@@ -436,11 +448,11 @@ class Parser:
 
     def getJunk(
         self,
-        ctx: Union[Parser.Context, DefinesParser.Context],
+        ctx: Parser.Context,
         offset: int,
-        *expressions,
+        *expressions: re.Pattern[str],
     ) -> Junk:
-        junkend = None
+        junkend: Optional[int] = None
         for exp in expressions:
             m = exp.search(ctx.contents, offset)
             if m:
@@ -449,9 +461,9 @@ class Parser:
 
     def createEntity(
         self,
-        ctx: DefinesParser.Context,
-        m: re.Match,
-        current_comment: Optional[DefinesParser.Comment],
+        ctx: Parser.Context,
+        m: re.Match[str],
+        current_comment: Optional[Comment_],
         white_space: Optional[Whitespace],
     ) -> Entity:
         return Entity(
@@ -459,7 +471,7 @@ class Parser:
         )
 
     @classmethod
-    def findDuplicates(cls, entities: Any) -> None:
+    def findDuplicates(cls, entities: Iterable[Entity]) -> Iterator[str]:
         found = Counter(entity.key for entity in entities)
         for entity_id, cnt in found.items():
             if cnt > 1:

--- a/l10n_parser/base.py
+++ b/l10n_parser/base.py
@@ -9,16 +9,19 @@ import codecs
 import re
 from collections import Counter
 from typing import (
+    TYPE_CHECKING,
     Any,
     Iterable,
     Iterator,
     List,
-    Literal,
     Optional,
     Tuple,
     Union,
     overload,
 )
+
+if TYPE_CHECKING:
+    from typing_extensions import Literal
 
 # The allowed capabilities for the Parsers.  They define the exact strategy
 # used by ContentComparer.merge.

--- a/l10n_parser/base.py
+++ b/l10n_parser/base.py
@@ -2,10 +2,19 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from __future__ import annotations
+
 import bisect
 import codecs
 import re
 from collections import Counter
+from typing import TYPE_CHECKING, Any, Iterator, Optional, Tuple, Union
+
+if TYPE_CHECKING:
+    from .android import XMLComment, XMLWhitespace
+    from .defines import DefinesParser
+    from .dtd import DTDEntity, DTDParser
+
 
 # The allowed capabilities for the Parsers.  They define the exact strategy
 # used by ContentComparer.merge.
@@ -36,7 +45,17 @@ class Entry:
     <--- definition ---->
     """
 
-    def __init__(self, ctx, pre_comment, inner_white, span, key_span, val_span):
+    def __init__(
+        self,
+        ctx: Optional[Union[Parser.Context, DefinesParser.Context]],
+        pre_comment: Optional[
+            Union[XMLComment, DTDParser.Comment, DefinesParser.Comment]
+        ],
+        inner_white: Optional[Union[XMLWhitespace, Whitespace]],
+        span: Optional[Union[Tuple[None, None], Tuple[int, int]]],
+        key_span: Optional[Union[Tuple[None, None], Tuple[int, int]]],
+        val_span: Optional[Union[Tuple[None, None], Tuple[int, int]]],
+    ) -> None:
         self.ctx = ctx
         self.span = span
         self.key_span = key_span
@@ -44,7 +63,7 @@ class Entry:
         self.pre_comment = pre_comment
         self.inner_white = inner_white
 
-    def position(self, offset=0):
+    def position(self, offset: int = 0) -> Tuple[int, int]:
         """Get the 1-based line and column of the character
         with given offset into the Entity.
 
@@ -56,7 +75,7 @@ class Entry:
             pos = self.span[0] + offset
         return self.ctx.linecol(pos)
 
-    def value_position(self, offset=0):
+    def value_position(self, offset: int = 0) -> Tuple[int, int]:
         """Get the 1-based line and column of the character
         with given offset into the value.
 
@@ -69,39 +88,39 @@ class Entry:
             pos = self.val_span[0] + offset
         return self.ctx.linecol(pos)
 
-    def _span_start(self):
+    def _span_start(self) -> int:
         start = self.span[0]
         if hasattr(self, "pre_comment") and self.pre_comment is not None:
             start = self.pre_comment.span[0]
         return start
 
     @property
-    def all(self):
+    def all(self) -> str:
         start = self._span_start()
         end = self.span[1]
         return self.ctx.contents[start:end]
 
     @property
-    def key(self):
+    def key(self) -> str:
         return self.ctx.contents[self.key_span[0] : self.key_span[1]]
 
     @property
-    def raw_val(self):
+    def raw_val(self) -> str:
         if self.val_span is None:
             return None
         return self.ctx.contents[self.val_span[0] : self.val_span[1]]
 
     @property
-    def val(self):
+    def val(self) -> str:
         return self.raw_val
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.key
 
     re_br = re.compile("<br[ \t\r\n]*/?>", re.U)
     re_sgml = re.compile(r"</?\w+.*?>", re.U | re.M)
 
-    def count_words(self):
+    def count_words(self) -> int:
         """Count the words in an English string.
         Replace a couple of xml markup to make that safer, too.
         """
@@ -109,7 +128,7 @@ class Entry:
         value = self.re_sgml.sub("", value)
         return len(value.split())
 
-    def equals(self, other):
+    def equals(self, other: Union[Entity, DTDEntity, LiteralEntity]) -> bool:
         return self.key == other.key and self.val == other.val
 
 
@@ -123,7 +142,7 @@ class StickyEntry(Entry):
 
 class Entity(Entry):
     @property
-    def localized(self):
+    def localized(self) -> bool:
         """Is this entity localized.
 
         Always true for monolingual files.
@@ -155,14 +174,14 @@ class LiteralEntity(Entity):
     It's storing string literals for key, raw_val and all instead of spans.
     """
 
-    def __init__(self, key, val, all):
+    def __init__(self, key: str, val: str, all: str) -> None:
         super().__init__(None, None, None, None, None, None)
         self._key = key
         self._raw_val = val
         self._all = all
 
     @property
-    def key(self):
+    def key(self) -> str:
         return self._key
 
     @property
@@ -170,19 +189,21 @@ class LiteralEntity(Entity):
         return self._raw_val
 
     @property
-    def all(self):
+    def all(self) -> str:
         return self._all
 
 
 class PlaceholderEntity(LiteralEntity):
     """Subclass of Entity to be removed in merges."""
 
-    def __init__(self, key):
+    def __init__(self, key: str) -> None:
         super().__init__(key, "", "\nplaceholder\n")
 
 
 class Comment(Entry):
-    def __init__(self, ctx, span):
+    def __init__(
+        self, ctx: Union[Parser.Context, DefinesParser.Context], span: Tuple[int, int]
+    ) -> None:
         self.ctx = ctx
         self.span = span
         self.val_span = None
@@ -193,12 +214,12 @@ class Comment(Entry):
         return None
 
     @property
-    def val(self):
+    def val(self) -> str:
         if self._val_cache is None:
             self._val_cache = self.all
         return self._val_cache
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.all
 
 
@@ -211,7 +232,7 @@ class OffsetComment(Comment):
     comment_offset = 1
 
     @property
-    def val(self):
+    def val(self) -> str:
         if self._val_cache is None:
             self._val_cache = "".join(
                 line[self.comment_offset :] for line in self.all.splitlines(True)
@@ -228,13 +249,17 @@ class Junk:
 
     junkid = 0
 
-    def __init__(self, ctx, span):
+    def __init__(
+        self,
+        ctx: Optional[Union[Parser.Context, DefinesParser.Context]],
+        span: Tuple[int, int],
+    ) -> None:
         self.ctx = ctx
         self.span = span
         self.__class__.junkid += 1
         self.key = "_junk_%d_%d-%d" % (self.__class__.junkid, span[0], span[1])
 
-    def position(self, offset=0):
+    def position(self, offset: int = 0) -> Tuple[int, int]:
         """Get the 1-based line and column of the character
         with given offset into the Entity.
 
@@ -247,25 +272,25 @@ class Junk:
         return self.ctx.linecol(pos)
 
     @property
-    def all(self):
+    def all(self) -> str:
         return self.ctx.contents[self.span[0] : self.span[1]]
 
     @property
-    def raw_val(self):
+    def raw_val(self) -> str:
         return self.all
 
     @property
-    def val(self):
+    def val(self) -> str:
         return self.all
 
-    def error_message(self):
+    def error_message(self) -> str:
         params = (self.val,) + self.position() + self.position(-1)
         return (
             'Unparsed content "%s" from line %d column %d'
             " to line %d column %d" % params
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.key
 
 
@@ -274,11 +299,13 @@ class Whitespace(Entry):
     if allowed
     """
 
-    def __init__(self, ctx, span):
+    def __init__(
+        self, ctx: Union[Parser.Context, DefinesParser.Context], span: Tuple[int, int]
+    ) -> None:
         self.ctx = ctx
         self.span = self.key_span = self.val_span = span
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.raw_val
 
 
@@ -303,7 +330,7 @@ class Parser:
             # cache split lines
             self._lines = None
 
-        def linecol(self, position):
+        def linecol(self, position: int) -> Tuple[int, int]:
             "Returns 1-based line and column numbers."
             if self._lines is None:
                 nl = re.compile("\n", re.M)
@@ -315,17 +342,17 @@ class Parser:
 
             return line_offset + 1, col_offset + 1
 
-    def __init__(self):
+    def __init__(self) -> None:
         if not hasattr(self, "encoding"):
             self.encoding = "utf-8"
         self.ctx = None
 
-    def readFile(self, file):
+    def readFile(self, file: str) -> None:
         """Read contents from disk, with universal_newlines"""
         with open(file, encoding=self.encoding, errors="replace", newline=None) as f:
             self.readUnicode(f.read())
 
-    def readContents(self, contents):
+    def readContents(self, contents: bytes) -> None:
         """Read contents and create parsing context.
 
         contents are in native encoding, but with normalized line endings.
@@ -333,13 +360,13 @@ class Parser:
         (contents, _) = codecs.getdecoder(self.encoding)(contents, "replace")
         self.readUnicode(contents)
 
-    def readUnicode(self, contents):
+    def readUnicode(self, contents: str) -> None:
         self.ctx = self.Context(contents)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Any]:
         return self.walk(only_localizable=True)
 
-    def walk(self, only_localizable=False):
+    def walk(self, only_localizable: bool = False) -> Iterator[Any]:
         if not self.ctx:
             # loading file failed, or we just didn't load anything
             return
@@ -357,7 +384,9 @@ class Parser:
 
             next_offset = entity.span[1]
 
-    def getNext(self, ctx, offset):
+    def getNext(
+        self, ctx: Parser.Context, offset: int
+    ) -> Union[Junk, DTDEntity, DTDParser.Comment, Whitespace]:
         """Parse the next fragment.
 
         Parse comments first, then white-space.
@@ -405,7 +434,12 @@ class Parser:
             return white_space
         return self.getJunk(ctx, junk_offset, self.reKey, self.reComment)
 
-    def getJunk(self, ctx, offset, *expressions):
+    def getJunk(
+        self,
+        ctx: Union[Parser.Context, DefinesParser.Context],
+        offset: int,
+        *expressions,
+    ) -> Junk:
         junkend = None
         for exp in expressions:
             m = exp.search(ctx.contents, offset)
@@ -413,13 +447,19 @@ class Parser:
                 junkend = min(junkend, m.start()) if junkend else m.start()
         return Junk(ctx, (offset, junkend or len(ctx.contents)))
 
-    def createEntity(self, ctx, m, current_comment, white_space):
+    def createEntity(
+        self,
+        ctx: DefinesParser.Context,
+        m: re.Match,
+        current_comment: Optional[DefinesParser.Comment],
+        white_space: Optional[Whitespace],
+    ) -> Entity:
         return Entity(
             ctx, current_comment, white_space, m.span(), m.span("key"), m.span("val")
         )
 
     @classmethod
-    def findDuplicates(cls, entities):
+    def findDuplicates(cls, entities: Any) -> None:
         found = Counter(entity.key for entity in entities)
         for entity_id, cnt in found.items():
             if cnt > 1:

--- a/l10n_parser/base.py
+++ b/l10n_parser/base.py
@@ -378,12 +378,12 @@ class Parser:
         return self.walk(only_localizable=True)
 
     @overload
-    def walk(self, only_localizable: Literal[True]) -> Iterator[Union[Entity, Junk]]:
-        ...
+    def walk(
+        self, only_localizable: Literal[True]
+    ) -> Iterator[Union[Entity, Junk]]: ...
 
     @overload
-    def walk(self, only_localizable: bool = False) -> Iterator[Any]:
-        ...
+    def walk(self, only_localizable: bool = False) -> Iterator[Any]: ...
 
     def walk(self, only_localizable: bool = False) -> Iterator[Any]:
         if not self.ctx:

--- a/l10n_parser/defines.py
+++ b/l10n_parser/defines.py
@@ -13,6 +13,9 @@ from .base import CAN_COPY, Entity, Entry, Junk, OffsetComment, Parser, Whitespa
 class DefinesInstruction(Entry):
     """Entity-like object representing processing instructions in inc files"""
 
+    raw_val: str
+    val: str
+
     def __init__(
         self,
         ctx: DefinesParser.Context,
@@ -53,7 +56,7 @@ class DefinesParser(Parser):
         Parser.__init__(self)
 
     def getNext(
-        self, ctx: DefinesParser.Context, offset: int
+        self, ctx: DefinesParser.Context, offset: int  # type:ignore[override]
     ) -> Union[DefinesInstruction, Entity, Whitespace, DefinesParser.Comment, Junk]:
         junk_offset = offset
         contents = ctx.contents

--- a/l10n_parser/defines.py
+++ b/l10n_parser/defines.py
@@ -2,20 +2,28 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import re
+from __future__ import annotations
 
-from .base import CAN_COPY, Entry, Junk, OffsetComment, Parser, Whitespace
+import re
+from typing import Tuple, Union
+
+from .base import CAN_COPY, Entity, Entry, Junk, OffsetComment, Parser, Whitespace
 
 
 class DefinesInstruction(Entry):
     """Entity-like object representing processing instructions in inc files"""
 
-    def __init__(self, ctx, span, val_span):
+    def __init__(
+        self,
+        ctx: DefinesParser.Context,
+        span: Tuple[int, int],
+        val_span: Tuple[int, int],
+    ) -> None:
         self.ctx = ctx
         self.span = span
         self.key_span = self.val_span = val_span
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.raw_val
 
 
@@ -30,11 +38,11 @@ class DefinesParser(Parser):
         comment_offset = 2
 
     class Context(Parser.Context):
-        def __init__(self, contents):
+        def __init__(self, contents: str) -> None:
             super().__init__(contents)
             self.filter_empty_lines = False
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.reComment = re.compile("(?:^# .*?\n)*(?:^# [^\n]*)", re.M)
         # corresponds to
         # https://hg.mozilla.org/mozilla-central/file/72ee4800d4156931c89b58bd807af4a3083702bb/python/mozbuild/mozbuild/preprocessor.py#l561  # noqa
@@ -44,7 +52,9 @@ class DefinesParser(Parser):
         self.rePI = re.compile(r"#(?P<val>\w+[ \t]+[^\n]+)", re.M)
         Parser.__init__(self)
 
-    def getNext(self, ctx, offset):
+    def getNext(
+        self, ctx: DefinesParser.Context, offset: int
+    ) -> Union[DefinesInstruction, Entity, Whitespace, DefinesParser.Comment, Junk]:
         junk_offset = offset
         contents = ctx.contents
 

--- a/l10n_parser/dtd.py
+++ b/l10n_parser/dtd.py
@@ -116,7 +116,7 @@ class DTDParser(Parser):
     def createEntity(
         self,
         ctx: Parser.Context,
-        m: re.Match,
+        m: re.Match[str],
         current_comment: Optional[DTDParser.Comment],  # type:ignore[override]
         white_space: Optional[Whitespace],
     ) -> DTDEntity:

--- a/l10n_parser/dtd.py
+++ b/l10n_parser/dtd.py
@@ -8,12 +8,13 @@ import re
 from html import unescape as html_unescape
 from typing import Optional, Tuple, Union
 
-from .base import Comment, Entity, Junk, Parser, Whitespace
+from .base import Comment as Comment_
+from .base import Entity, Junk, Parser, Whitespace
 
 
 class DTDEntityMixin:
     @property
-    def val(self):
+    def val(self) -> str:
         """Unescape HTML entities into corresponding Unicode characters.
 
         Named (&amp;), decimal (&#38;), and hex (&#x26; and &#x0026;) formats
@@ -24,7 +25,7 @@ class DTDEntityMixin:
 
             https://github.com/python/cpython/blob/3.7/Lib/html/entities.py
         """
-        return html_unescape(self.raw_val)
+        return html_unescape(self.raw_val)  # type: ignore
 
     def value_position(
         self, offset: Union[Tuple[int, int], int] = 0
@@ -32,7 +33,7 @@ class DTDEntityMixin:
         # DTDChecker already returns tuples of (line, col) positions
         if isinstance(offset, tuple):
             line_pos, col_pos = offset
-            line, col = super().value_position()
+            line, col = super().value_position()  # type: ignore
             if line_pos == 1:
                 col = col + col_pos
             else:
@@ -40,7 +41,7 @@ class DTDEntityMixin:
                 line += line_pos - 1
             return line, col
         else:
-            return super().value_position(offset)
+            return super().value_position(offset)  # type: ignore
 
 
 class DTDEntity(DTDEntityMixin, Entity):
@@ -83,7 +84,7 @@ class DTDParser(Parser):
         "(?:[ \t]*(?:" + XmlComment + "[ \t\r\n]*)*\n?)?"
     )
 
-    class Comment(Comment):
+    class Comment(Comment_):
         @property
         def val(self) -> str:
             if self._val_cache is None:
@@ -110,13 +111,13 @@ class DTDParser(Parser):
                 entity = DTDEntity(
                     ctx, None, None, m.span(), m.span("key"), m.span("val")
                 )
-        return entity
+        return entity  # type: ignore
 
     def createEntity(
         self,
         ctx: Parser.Context,
         m: re.Match,
-        current_comment: Optional[DTDParser.Comment],
+        current_comment: Optional[DTDParser.Comment],  # type:ignore[override]
         white_space: Optional[Whitespace],
     ) -> DTDEntity:
         valspan = m.span("val")

--- a/l10n_parser/fluent.py
+++ b/l10n_parser/fluent.py
@@ -2,7 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from __future__ import annotations
+
 import re
+from typing import Iterator, Optional, Tuple, Union
 
 from fluent.syntax import FluentParser as FTLParser
 from fluent.syntax import ast as ftl
@@ -22,19 +25,19 @@ from .base import (
 
 
 class WordCounter(Visitor):
-    def __init__(self):
+    def __init__(self) -> None:
         self.word_count = 0
 
-    def generic_visit(self, node):
+    def generic_visit(self, node: ftl.BaseNode) -> None:
         if isinstance(node, (ftl.Span, ftl.Annotation, ftl.BaseComment)):
             return
         super().generic_visit(node)
 
-    def visit_SelectExpression(self, node):
+    def visit_SelectExpression(self, node: ftl.SelectExpression) -> None:
         # optimize select expressions to only go through the variants
         self.visit(node.variants)
 
-    def visit_TextElement(self, node):
+    def visit_TextElement(self, node: ftl.TextElement) -> None:
         self.word_count += len(node.value.split())
 
 
@@ -57,7 +60,9 @@ class FluentEntity(Entity):
     # Fields ignored when comparing two entities.
     ignored_fields = ["comment", "span"]
 
-    def __init__(self, ctx, entry):
+    def __init__(
+        self, ctx: Parser.Context, entry: Union[ftl.Message, ftl.Term]
+    ) -> None:
         start = entry.span.start
         end = entry.span.end
 
@@ -86,7 +91,7 @@ class FluentEntity(Entity):
         self.pre_comment = None
 
     @property
-    def root_node(self):
+    def root_node(self) -> ftl.Message:
         """AST node at which to start traversal for count_words.
 
         By default we count words in the value and in all attributes.
@@ -95,7 +100,7 @@ class FluentEntity(Entity):
 
     _word_count = None
 
-    def count_words(self):
+    def count_words(self) -> int:
         if self._word_count is None:
             counter = WordCounter()
             counter.visit(self.root_node)
@@ -103,12 +108,12 @@ class FluentEntity(Entity):
 
         return self._word_count
 
-    def equals(self, other):
+    def equals(self, other: Union[FluentTerm, FluentMessage]) -> bool:
         return self.entry.equals(other.entry, ignored_fields=self.ignored_fields)
 
     # In Fluent we treat entries as a whole.  FluentChecker reports errors at
     # offsets calculated from the beginning of the entry.
-    def value_position(self, offset=None):
+    def value_position(self, offset: Optional[int] = None) -> Tuple[int, int]:
         if offset is None:
             # no offset given, use our value start or id end
             if self.val_span:
@@ -118,14 +123,14 @@ class FluentEntity(Entity):
         return self.position(offset)
 
     @property
-    def attributes(self):
+    def attributes(self) -> Iterator[FluentAttribute]:
         for attr_node in self.entry.attributes:
             yield FluentAttribute(self, attr_node)
 
     def unwrap(self):
         return self.all
 
-    def wrap(self, raw_val):
+    def wrap(self, raw_val: str) -> LiteralEntity:
         """Create literal entity the given raw value.
 
         For Fluent, we're exposing the message source to tools like
@@ -147,7 +152,7 @@ class FluentTerm(FluentEntity):
     ignored_fields = ["attributes", "comment", "span"]
 
     @property
-    def root_node(self):
+    def root_node(self) -> ftl.Pattern:
         """AST node at which to start traversal for count_words.
 
         In Fluent Terms we only count words in the value. Attributes are
@@ -157,7 +162,12 @@ class FluentTerm(FluentEntity):
 
 
 class FluentComment(Comment):
-    def __init__(self, ctx, span, entry):
+    def __init__(
+        self,
+        ctx: Parser.Context,
+        span: Tuple[int, int],
+        entry: Union[ftl.Comment, ftl.GroupComment, ftl.ResourceComment],
+    ) -> None:
         super().__init__(ctx, span)
         self._val_cache = entry.content
 
@@ -165,11 +175,13 @@ class FluentComment(Comment):
 class FluentParser(Parser):
     capabilities = CAN_SKIP
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.ftl_parser = FTLParser()
 
-    def walk(self, only_localizable=False):
+    def walk(
+        self, only_localizable: bool = False
+    ) -> Iterator[Union[FluentTerm, FluentMessage, Whitespace, Junk, FluentComment]]:
         if not self.ctx:
             # loading file failed, or we just didn't load anything
             return

--- a/l10n_parser/fluent.py
+++ b/l10n_parser/fluent.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import re
-from typing import Iterator, Optional, Tuple, Union
+from typing import Iterator, Optional, Tuple, Union, cast
 
 from fluent.syntax import FluentParser as FTLParser
 from fluent.syntax import ast as ftl
@@ -59,26 +59,30 @@ class FluentAttribute(Entry):
 class FluentEntity(Entity):
     # Fields ignored when comparing two entities.
     ignored_fields = ["comment", "span"]
+    val_span: Optional[Tuple[int, int]]  # type:ignore[assignment]
 
     def __init__(
         self, ctx: Parser.Context, entry: Union[ftl.Message, ftl.Term]
     ) -> None:
-        start = entry.span.start
-        end = entry.span.end
+        span = cast(ftl.Span, entry.span)
+        start = span.start
+        end = span.end
 
         self.ctx = ctx
         self.span = (start, end)
 
+        id_span = cast(ftl.Span, entry.id.span)
         if isinstance(entry, ftl.Term):
             # Terms don't have their '-' as part of the id, use the prior
             # character
-            self.key_span = (entry.id.span.start - 1, entry.id.span.end)
+            self.key_span = (id_span.start - 1, id_span.end)
         else:
             # Message
-            self.key_span = (entry.id.span.start, entry.id.span.end)
+            self.key_span = (id_span.start, id_span.end)
 
         if entry.value is not None:
-            self.val_span = (entry.value.span.start, entry.value.span.end)
+            val_span = cast(ftl.Span, entry.value.span)
+            self.val_span = (val_span.start, val_span.end)
         else:
             self.val_span = None
 
@@ -91,7 +95,7 @@ class FluentEntity(Entity):
         self.pre_comment = None
 
     @property
-    def root_node(self) -> ftl.Message:
+    def root_node(self) -> Union[ftl.Message, ftl.Term, ftl.Pattern, None]:
         """AST node at which to start traversal for count_words.
 
         By default we count words in the value and in all attributes.
@@ -108,7 +112,9 @@ class FluentEntity(Entity):
 
         return self._word_count
 
-    def equals(self, other: Union[FluentTerm, FluentMessage]) -> bool:
+    def equals(
+        self, other: Union[FluentTerm, FluentMessage]  # type:ignore[override]
+    ) -> bool:
         return self.entry.equals(other.entry, ignored_fields=self.ignored_fields)
 
     # In Fluent we treat entries as a whole.  FluentChecker reports errors at
@@ -152,7 +158,7 @@ class FluentTerm(FluentEntity):
     ignored_fields = ["attributes", "comment", "span"]
 
     @property
-    def root_node(self) -> ftl.Pattern:
+    def root_node(self) -> Union[ftl.Pattern, None]:
         """AST node at which to start traversal for count_words.
 
         In Fluent Terms we only count words in the value. Attributes are
@@ -179,7 +185,7 @@ class FluentParser(Parser):
         super().__init__()
         self.ftl_parser = FTLParser()
 
-    def walk(
+    def walk(  # type:ignore[override]
         self, only_localizable: bool = False
     ) -> Iterator[Union[FluentTerm, FluentMessage, Whitespace, Junk, FluentComment]]:
         if not self.ctx:
@@ -191,32 +197,38 @@ class FluentParser(Parser):
         last_span_end = 0
 
         for entry in resource.body:
+            span = cast(ftl.Span, entry.span)
             if not only_localizable:
-                if entry.span.start > last_span_end:
-                    yield Whitespace(self.ctx, (last_span_end, entry.span.start))
+                if span.start > last_span_end:
+                    yield Whitespace(self.ctx, (last_span_end, span.start))
 
             if isinstance(entry, ftl.Message):
                 yield FluentMessage(self.ctx, entry)
             elif isinstance(entry, ftl.Term):
                 yield FluentTerm(self.ctx, entry)
             elif isinstance(entry, ftl.Junk):
-                start = entry.span.start
-                end = entry.span.end
-                # strip leading whitespace
-                start += re.match("[ \t\r\n]*", entry.content).end()
-                if not only_localizable and entry.span.start < start:
-                    yield Whitespace(self.ctx, (entry.span.start, start))
-                # strip trailing whitespace
-                ws, we = re.search("[ \t\r\n]*$", entry.content).span()
-                end -= we - ws
+                start = span.start
+                end = span.end
+                if entry.content:
+                    # strip leading whitespace
+                    ms = re.match("[ \t\r\n]*", entry.content)
+                    if ms and ms.end() > 0:
+                        start += ms.end()
+                        if not only_localizable:
+                            yield Whitespace(self.ctx, (span.start, start))
+                    # strip trailing whitespace
+                    me = re.search("[ \t\r\n]*$", entry.content)
+                    if me:
+                        ws, we = me.span()
+                        end -= we - ws
                 yield Junk(self.ctx, (start, end))
-                if not only_localizable and end < entry.span.end:
-                    yield Whitespace(self.ctx, (end, entry.span.end))
+                if not only_localizable and end < span.end:
+                    yield Whitespace(self.ctx, (end, span.end))
             elif isinstance(entry, ftl.BaseComment) and not only_localizable:
-                span = (entry.span.start, entry.span.end)
-                yield FluentComment(self.ctx, span, entry)
+                span_ = (span.start, span.end)
+                yield FluentComment(self.ctx, span_, entry)
 
-            last_span_end = entry.span.end
+            last_span_end = span.end
 
         # Yield Whitespace at the EOF.
         if not only_localizable:

--- a/l10n_parser/fluent.py
+++ b/l10n_parser/fluent.py
@@ -44,13 +44,15 @@ class WordCounter(Visitor):
 class FluentAttribute(Entry):
     ignored_fields = ["span"]
 
-    def __init__(self, entity, attr_node):
+    def __init__(self, entity: FluentEntity, attr_node: ftl.Attribute):
         self.ctx = entity.ctx
         self.attr = attr_node
-        self.key_span = (attr_node.id.span.start, attr_node.id.span.end)
-        self.val_span = (attr_node.value.span.start, attr_node.value.span.end)
+        id_span = cast(ftl.Span, attr_node.id.span)
+        self.key_span = (id_span.start, id_span.end)
+        val_span = cast(ftl.Span, attr_node.value.span)
+        self.val_span = (val_span.start, val_span.end)
 
-    def equals(self, other):
+    def equals(self, other: Entity) -> bool:
         if not isinstance(other, FluentAttribute):
             return False
         return self.attr.equals(other.attr, ignored_fields=self.ignored_fields)
@@ -133,7 +135,7 @@ class FluentEntity(Entity):
         for attr_node in self.entry.attributes:
             yield FluentAttribute(self, attr_node)
 
-    def unwrap(self):
+    def unwrap(self) -> str:
         return self.all
 
     def wrap(self, raw_val: str) -> LiteralEntity:

--- a/l10n_parser/ini.py
+++ b/l10n_parser/ini.py
@@ -49,7 +49,7 @@ class IniParser(Parser):
         if m:
             return IniSection(ctx, m.span(), m.span("val"))
 
-        return super().getNext(ctx, offset)
+        return super().getNext(ctx, offset)  # type: ignore
 
     def getJunk(self, ctx: Parser.Context, offset: int, *expressions) -> Junk:
         # base.Parser.getNext calls us with self.reKey, self.reComment.

--- a/l10n_parser/ini.py
+++ b/l10n_parser/ini.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import re
-from typing import Union
+from typing import Tuple, Union
 
 from .base import Entity, Entry, Junk, OffsetComment, Parser, Whitespace
 
@@ -13,13 +13,15 @@ from .base import Entity, Entry, Junk, OffsetComment, Parser, Whitespace
 class IniSection(Entry):
     """Entity-like object representing sections in ini files"""
 
-    def __init__(self, ctx, span, val_span):
+    def __init__(
+        self, ctx: Parser.Context, span: Tuple[int, int], val_span: Tuple[int, int]
+    ):
         self.ctx = ctx
         self.span = span
         self.key_span = self.val_span = val_span
 
-    def __repr__(self):
-        return self.raw_val
+    def __repr__(self) -> str:
+        return self.raw_val  # type:ignore
 
 
 class IniParser(Parser):
@@ -35,7 +37,7 @@ class IniParser(Parser):
 
     Comment = OffsetComment
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.reComment = re.compile("(?:^[;#][^\n]*\n)*(?:^[;#][^\n]*)", re.M)
         self.reSection = re.compile(r"\[(?P<val>.*?)\]", re.M)
         self.reKey = re.compile("(?P<key>.+?)=(?P<val>.*)", re.M)
@@ -51,7 +53,9 @@ class IniParser(Parser):
 
         return super().getNext(ctx, offset)  # type: ignore
 
-    def getJunk(self, ctx: Parser.Context, offset: int, *expressions) -> Junk:
+    def getJunk(
+        self, ctx: Parser.Context, offset: int, *expressions: re.Pattern[str]
+    ) -> Junk:
         # base.Parser.getNext calls us with self.reKey, self.reComment.
         # Add self.reSection to the end-of-junk expressions
         expressions = expressions + (self.reSection,)

--- a/l10n_parser/ini.py
+++ b/l10n_parser/ini.py
@@ -2,9 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import re
+from __future__ import annotations
 
-from .base import Entry, OffsetComment, Parser
+import re
+from typing import Union
+
+from .base import Entity, Entry, Junk, OffsetComment, Parser, Whitespace
 
 
 class IniSection(Entry):
@@ -38,7 +41,9 @@ class IniParser(Parser):
         self.reKey = re.compile("(?P<key>.+?)=(?P<val>.*)", re.M)
         Parser.__init__(self)
 
-    def getNext(self, ctx, offset):
+    def getNext(
+        self, ctx: Parser.Context, offset: int
+    ) -> Union[Junk, OffsetComment, IniSection, Entity, Whitespace]:
         contents = ctx.contents
         m = self.reSection.match(contents, offset)
         if m:
@@ -46,7 +51,7 @@ class IniParser(Parser):
 
         return super().getNext(ctx, offset)
 
-    def getJunk(self, ctx, offset, *expressions):
+    def getJunk(self, ctx: Parser.Context, offset: int, *expressions) -> Junk:
         # base.Parser.getNext calls us with self.reKey, self.reComment.
         # Add self.reSection to the end-of-junk expressions
         expressions = expressions + (self.reSection,)

--- a/l10n_parser/po.py
+++ b/l10n_parser/po.py
@@ -6,24 +6,25 @@
 
 Parses gettext po and pot files.
 """
-
+from __future__ import annotations
 
 import re
+from typing import List, Optional, Tuple, Union
 
-from .base import CAN_SKIP, BadEntity, Entity, Parser
+from .base import CAN_SKIP, BadEntity, Comment, Entity, Parser
 
 
 class PoEntityMixin:
     @property
-    def val(self):
+    def val(self) -> str:
         return self.stringlist_val if self.stringlist_val else self.stringlist_key[0]
 
     @property
-    def key(self):
+    def key(self) -> Union[Tuple[str, str], Tuple[str, None]]:
         return self.stringlist_key
 
     @property
-    def localized(self):
+    def localized(self) -> bool:
         # gettext denotes a non-localized string by an empty value
         return bool(self.stringlist_val)
 
@@ -36,7 +37,7 @@ class PoEntity(PoEntityMixin, Entity):
 
 
 # Unescape and concat a string list
-def eval_stringlist(lines):
+def eval_stringlist(lines: List[str]) -> str:
     return "".join(
         (
             line.replace(r"\\", "\\")
@@ -63,10 +64,16 @@ class PoParser(Parser):
     # `"`
     reListItem = re.compile(r'[ \t\r\n]*"((?:\\[\\trn"]|[^"\n\\])*)"')
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
-    def createEntity(self, ctx, m, current_comment, white_space):
+    def createEntity(
+        self,
+        ctx: Parser.Context,
+        m: re.Match,
+        current_comment: Optional[Comment],
+        white_space: None,
+    ) -> PoEntity:
         start = cursor = m.start()
         id_start = cursor
         try:
@@ -98,7 +105,9 @@ class PoParser(Parser):
         e.stringlist_val = msgstr
         return e
 
-    def _parse_string_list(self, ctx, cursor, key):
+    def _parse_string_list(
+        self, ctx: Parser.Context, cursor: int, key: str
+    ) -> Tuple[str, int]:
         if not ctx.contents.startswith(key, cursor):
             raise BadEntity
         cursor += len(key)

--- a/l10n_parser/po.py
+++ b/l10n_parser/po.py
@@ -31,7 +31,7 @@ class PoEntity(Entity):
         # gettext denotes a non-localized string by an empty value
         return bool(self.stringlist_val)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.key[0]
 
 
@@ -69,7 +69,7 @@ class PoParser(Parser):
     def createEntity(
         self,
         ctx: Parser.Context,
-        m: re.Match,
+        m: re.Match[str],
         current_comment: Optional[Comment],
         white_space: None,  # type:ignore[override]
     ) -> PoEntity:

--- a/l10n_parser/po.py
+++ b/l10n_parser/po.py
@@ -14,13 +14,16 @@ from typing import List, Optional, Tuple, Union
 from .base import CAN_SKIP, BadEntity, Comment, Entity, Parser
 
 
-class PoEntityMixin:
+class PoEntity(Entity):
+    stringlist_key: Tuple[str, Union[str, None]]
+    stringlist_val: str
+
     @property
     def val(self) -> str:
         return self.stringlist_val if self.stringlist_val else self.stringlist_key[0]
 
     @property
-    def key(self) -> Union[Tuple[str, str], Tuple[str, None]]:
+    def key(self) -> Tuple[str, Union[str, None]]:  # type:ignore[override]
         return self.stringlist_key
 
     @property
@@ -30,10 +33,6 @@ class PoEntityMixin:
 
     def __repr__(self):
         return self.key[0]
-
-
-class PoEntity(PoEntityMixin, Entity):
-    pass
 
 
 # Unescape and concat a string list
@@ -72,15 +71,15 @@ class PoParser(Parser):
         ctx: Parser.Context,
         m: re.Match,
         current_comment: Optional[Comment],
-        white_space: None,
+        white_space: None,  # type:ignore[override]
     ) -> PoEntity:
         start = cursor = m.start()
         id_start = cursor
         try:
             msgctxt, cursor = self._parse_string_list(ctx, cursor, "msgctxt")
-            m = self.reWhitespace.match(ctx.contents, cursor)
-            if m:
-                cursor = m.end()
+            match = self.reWhitespace.match(ctx.contents, cursor)
+            if match:
+                cursor = match.end()
         except BadEntity:
             # no msgctxt is OK
             msgctxt = None
@@ -88,9 +87,9 @@ class PoParser(Parser):
             id_start = cursor
         msgid, cursor = self._parse_string_list(ctx, cursor, "msgid")
         id_end = cursor
-        m = self.reWhitespace.match(ctx.contents, cursor)
-        if m:
-            cursor = m.end()
+        match = self.reWhitespace.match(ctx.contents, cursor)
+        if match:
+            cursor = match.end()
         val_start = cursor
         msgstr, cursor = self._parse_string_list(ctx, cursor, "msgstr")
         e = PoEntity(

--- a/l10n_parser/properties.py
+++ b/l10n_parser/properties.py
@@ -26,7 +26,7 @@ class PropertiesEntityMixin:
                 return ""
             return self.known_escapes.get(found["single"], found["single"])
 
-        return self.escape.sub(unescape, self.raw_val)
+        return self.escape.sub(unescape, self.raw_val)  # type: ignore
 
 
 class PropertiesEntity(PropertiesEntityMixin, Entity):

--- a/l10n_parser/properties.py
+++ b/l10n_parser/properties.py
@@ -18,7 +18,7 @@ class PropertiesEntityMixin:
 
     @property
     def val(self) -> str:
-        def unescape(m):
+        def unescape(m: re.Match[str]) -> str:
             found = m.groupdict()
             if found["uni"]:
                 return chr(int(found["uni"][1:], 16))

--- a/l10n_parser/properties.py
+++ b/l10n_parser/properties.py
@@ -2,9 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import re
+from __future__ import annotations
 
-from .base import Entity, OffsetComment, Parser, Whitespace
+import re
+from typing import Union
+
+from .base import Entity, Junk, OffsetComment, Parser, Whitespace
 
 
 class PropertiesEntityMixin:
@@ -14,7 +17,7 @@ class PropertiesEntityMixin:
     known_escapes = {"n": "\n", "r": "\r", "t": "\t", "\\": "\\"}
 
     @property
-    def val(self):
+    def val(self) -> str:
         def unescape(m):
             found = m.groupdict()
             if found["uni"]:
@@ -33,14 +36,16 @@ class PropertiesEntity(PropertiesEntityMixin, Entity):
 class PropertiesParser(Parser):
     Comment = OffsetComment
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.reKey = re.compile("(?P<key>[^#! \t\r\n][^=:\n]*?)[ \t]*[:=][ \t]*", re.M)
         self.reComment = re.compile("(?:[#!][^\n]*\n)*(?:[#!][^\n]*)", re.M)
         self._escapedEnd = re.compile(r"\\+$")
         self._trailingWS = re.compile(r"[ \t\r\n]*(?:\n|\Z)", re.M)
         Parser.__init__(self)
 
-    def getNext(self, ctx, offset):
+    def getNext(
+        self, ctx: Parser.Context, offset: int
+    ) -> Union[Whitespace, OffsetComment, Junk, PropertiesEntity]:
         junk_offset = offset
         # overwritten to parse values line by line
         contents = ctx.contents

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ profile = "black"
 extra_standard_library = ["typing_extensions", "_typeshed"]
 
 [tool.mypy]
-strict = false
+exclude = "^tests/"
+strict = true
 
 [tool.setuptools]
 platforms = ["any"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
 max-line-length = 88
 select = C,E,F,W,B,B950
-extend-ignore = E203, E501, W503
+extend-ignore = E203, E501, W503, E704
 extend-exclude = .*, build


### PR DESCRIPTION
Based on types found by `monkeytype` in test call patterns, then manually adapted. Not guaranteed to be complete or perfect, but getting there.

CI checks using `mypy` are added.